### PR TITLE
stop video capture after UIViewController popped on iOS

### DIFF
--- a/ios/Classes/SwiftFlutterBarcodeScannerPlugin.swift
+++ b/ios/Classes/SwiftFlutterBarcodeScannerPlugin.swift
@@ -221,6 +221,11 @@ class BarcodeScannerViewController: UIViewController {
         super.viewWillAppear(animated)
         self.moveVertically()
     }
+
+    override public func viewDidDisappear(_ animated: Bool){
+        // Stop video capture
+        captureSession.stopRunning()
+    }
     
     // Init UI components needed
     func initUIComponents(){


### PR DESCRIPTION
On ios14, a green dot still remains at the top-right corner after the scan screen disappeared, which reminds the user that the camera is still working.
I added a `closeRunning()` in the `viewDidDisappear` callback to fix it.

![IMG_E39064F240C2-1](https://user-images.githubusercontent.com/15264428/113090166-bc8c0f80-921b-11eb-89d4-587efb1b7c10.jpeg)