### PR TITLE
Close scanning programmatically

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 30
+    namespace = "com.amolg.flutterbarcodescanner"
 
     defaultConfig {
         minSdkVersion 16

--- a/android/src/main/java/com/amolg/flutterbarcodescanner/BarcodeCaptureActivity.java
+++ b/android/src/main/java/com/amolg/flutterbarcodescanner/BarcodeCaptureActivity.java
@@ -103,6 +103,15 @@ public final class BarcodeCaptureActivity extends AppCompatActivity implements B
 
     private BroadcastReceiver finishBroadcast;
 
+    @Override
+    public Intent registerReceiver(BroadcastReceiver receiver, IntentFilter filter) {
+        if (Build.VERSION.SDK_INT >= 34 && getApplicationInfo().targetSdkVersion >= 34) {
+            int RECEIVER_EXPORTED = 2;
+            return super.registerReceiver(receiver, filter, RECEIVER_EXPORTED);
+        }
+        return super.registerReceiver(receiver, filter);
+    }
+
     /**
      * Initializes the UI and creates the detector pipeline.
      */

--- a/android/src/main/java/com/amolg/flutterbarcodescanner/BarcodeCaptureActivity.java
+++ b/android/src/main/java/com/amolg/flutterbarcodescanner/BarcodeCaptureActivity.java
@@ -20,6 +20,7 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
+import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -99,6 +100,8 @@ public final class BarcodeCaptureActivity extends AppCompatActivity implements B
     }
 
     private int flashStatus = USE_FLASH.OFF.ordinal();
+
+    private BroadcastReceiver finishBroadcast;
 
     /**
      * Initializes the UI and creates the detector pipeline.
@@ -253,6 +256,17 @@ public final class BarcodeCaptureActivity extends AppCompatActivity implements B
     protected void onResume() {
         super.onResume();
         startCameraSource();
+
+        finishBroadcast = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context arg0, Intent intent) {
+                String action = intent.getAction();
+                if (action.equals("finishCapture")) {
+                    finish();
+                }
+            }
+        };
+        registerReceiver(finishBroadcast, new IntentFilter("finishCapture"));
     }
 
     /**
@@ -264,6 +278,8 @@ public final class BarcodeCaptureActivity extends AppCompatActivity implements B
         if (mPreview != null) {
             mPreview.stop();
         }
+
+        unregisterReceiver(finishBroadcast);
     }
 
     /**

--- a/android/src/main/java/com/amolg/flutterbarcodescanner/FlutterBarcodeScannerPlugin.java
+++ b/android/src/main/java/com/amolg/flutterbarcodescanner/FlutterBarcodeScannerPlugin.java
@@ -92,6 +92,11 @@ public class FlutterBarcodeScannerPlugin implements MethodCallHandler, ActivityR
     public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
         try {
             pendingResult = result;
+            
+            if (call.method.equals("dismiss")) {
+                activity.sendBroadcast(new Intent("finishCapture"));
+                return;
+            }
 
             if (call.method.equals("scanBarcode")) {
                 if (!(call.arguments instanceof Map)) {
@@ -198,7 +203,9 @@ public class FlutterBarcodeScannerPlugin implements MethodCallHandler, ActivityR
                 activity.runOnUiThread(new Runnable() {
                     @Override
                     public void run() {
-                        barcodeStream.success(barcode.rawValue);
+                        if (barcodeStream != null) {
+                            barcodeStream.success(barcode.rawValue);
+                        }
                     }
                 });
             }

--- a/android/src/main/java/com/amolg/flutterbarcodescanner/FlutterBarcodeScannerPlugin.java
+++ b/android/src/main/java/com/amolg/flutterbarcodescanner/FlutterBarcodeScannerPlugin.java
@@ -39,7 +39,7 @@ import io.flutter.embedding.engine.plugins.lifecycle.FlutterLifecycleAdapter;
 public class FlutterBarcodeScannerPlugin implements MethodCallHandler, ActivityResultListener, StreamHandler, FlutterPlugin, ActivityAware {
     private static final String CHANNEL = "flutter_barcode_scanner";
 
-    private static FlutterActivity activity;
+    private static Activity activity;
     private static Result pendingResult;
     private Map<String, Object> arguments;
 
@@ -68,25 +68,25 @@ public class FlutterBarcodeScannerPlugin implements MethodCallHandler, ActivityR
     public FlutterBarcodeScannerPlugin() {
     }
 
-    private FlutterBarcodeScannerPlugin(FlutterActivity activity, final PluginRegistry.Registrar registrar) {
-        FlutterBarcodeScannerPlugin.activity = activity;
-    }
+    // private FlutterBarcodeScannerPlugin(FlutterActivity activity, final PluginRegistry.Registrar registrar) {
+    //     FlutterBarcodeScannerPlugin.activity = activity;
+    // }
 
     /**
      * Plugin registration.
      */
-    public static void registerWith(final PluginRegistry.Registrar registrar) {
-        if (registrar.activity() == null) {
-            return;
-        }
-        Activity activity = registrar.activity();
-        Application applicationContext = null;
-        if (registrar.context() != null) {
-            applicationContext = (Application) (registrar.context().getApplicationContext());
-        }
-        FlutterBarcodeScannerPlugin instance = new FlutterBarcodeScannerPlugin((FlutterActivity) registrar.activity(), registrar);
-        instance.createPluginSetup(registrar.messenger(), applicationContext, activity, registrar, null);
-    }
+    // public static void registerWith(final PluginRegistry.Registrar registrar) {
+    //     if (registrar.activity() == null) {
+    //         return;
+    //     }
+    //     Activity activity = registrar.activity();
+    //     Application applicationContext = null;
+    //     if (registrar.context() != null) {
+    //         applicationContext = (Application) (registrar.context().getApplicationContext());
+    //     }
+    //     FlutterBarcodeScannerPlugin instance = new FlutterBarcodeScannerPlugin((FlutterActivity) registrar.activity(), registrar);
+    //     instance.createPluginSetup(registrar.messenger(), applicationContext, activity, registrar, null);
+    // }
 
     @Override
     public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
@@ -215,8 +215,16 @@ public class FlutterBarcodeScannerPlugin implements MethodCallHandler, ActivityR
     }
 
     @Override
-    public void onAttachedToEngine(FlutterPluginBinding binding) {
-        pluginBinding = binding;
+    // public void onAttachedToEngine(FlutterPluginBinding binding) {
+    //     pluginBinding = binding;
+    // }
+    public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
+        this.pluginBinding = flutterPluginBinding;
+        this.channel = new MethodChannel(flutterPluginBinding.getBinaryMessenger(), CHANNEL);
+        this.channel.setMethodCallHandler(this);
+
+        this.eventChannel = new EventChannel(flutterPluginBinding.getBinaryMessenger(), "flutter_barcode_scanner_receiver");
+        this.eventChannel.setStreamHandler(this);
     }
 
     @Override
@@ -241,18 +249,16 @@ public class FlutterBarcodeScannerPlugin implements MethodCallHandler, ActivityR
      * @param messenger
      * @param applicationContext
      * @param activity
-     * @param registrar
      * @param activityBinding
      */
     private void createPluginSetup(
             final BinaryMessenger messenger,
             final Application applicationContext,
             final Activity activity,
-            final PluginRegistry.Registrar registrar,
             final ActivityPluginBinding activityBinding) {
 
 
-        this.activity = (FlutterActivity) activity;
+        this.activity = activity;
         eventChannel =
                 new EventChannel(messenger, "flutter_barcode_scanner_receiver");
         eventChannel.setStreamHandler(this);
@@ -261,19 +267,25 @@ public class FlutterBarcodeScannerPlugin implements MethodCallHandler, ActivityR
         this.applicationContext = applicationContext;
         channel = new MethodChannel(messenger, CHANNEL);
         channel.setMethodCallHandler(this);
-        if (registrar != null) {
-            // V1 embedding setup for activity listeners.
-            observer = new LifeCycleObserver(activity);
-            applicationContext.registerActivityLifecycleCallbacks(
-                    observer); // Use getApplicationContext() to avoid casting failures.
-            registrar.addActivityResultListener(this);
-        } else {
-            // V2 embedding setup for activity listeners.
-            activityBinding.addActivityResultListener(this);
-            lifecycle = FlutterLifecycleAdapter.getActivityLifecycle(activityBinding);
-            observer = new LifeCycleObserver(activity);
-            lifecycle.addObserver(observer);
-        }
+        // if (registrar != null) {
+        //     // V1 embedding setup for activity listeners.
+        //     observer = new LifeCycleObserver(activity);
+        //     applicationContext.registerActivityLifecycleCallbacks(
+        //             observer); // Use getApplicationContext() to avoid casting failures.
+        //     registrar.addActivityResultListener(this);
+        // } else {
+        //     // V2 embedding setup for activity listeners.
+        //     activityBinding.addActivityResultListener(this);
+        //     lifecycle = FlutterLifecycleAdapter.getActivityLifecycle(activityBinding);
+        //     observer = new LifeCycleObserver(activity);
+        //     lifecycle.addObserver(observer);
+        // }
+
+        // V2 embedding setup for activity listeners.
+        activityBinding.addActivityResultListener(this);
+        lifecycle = FlutterLifecycleAdapter.getActivityLifecycle(activityBinding);
+        observer = new LifeCycleObserver(activity);
+        lifecycle.addObserver(observer);
     }
 
     @Override
@@ -283,7 +295,6 @@ public class FlutterBarcodeScannerPlugin implements MethodCallHandler, ActivityR
                 pluginBinding.getBinaryMessenger(),
                 (Application) pluginBinding.getApplicationContext(),
                 activityBinding.getActivity(),
-                null,
                 activityBinding);
     }
 

--- a/ios/Classes/SwiftFlutterBarcodeScannerPlugin.swift
+++ b/ios/Classes/SwiftFlutterBarcodeScannerPlugin.swift
@@ -62,7 +62,7 @@ public class SwiftFlutterBarcodeScannerPlugin: NSObject, FlutterPlugin, ScanBarc
         let args:Dictionary<String, AnyObject> = call.arguments as! Dictionary<String, AnyObject>;
 
         if let dismissScanner = args["dismissScanner"] as? String{
-            SwiftFlutterBarcodeScannerPlugin._controller?.cancelButtonClicked();
+            SwiftFlutterBarcodeScannerPlugin._controller?.dismiss(animated: true);
             return;
         }
 

--- a/ios/Classes/SwiftFlutterBarcodeScannerPlugin.swift
+++ b/ios/Classes/SwiftFlutterBarcodeScannerPlugin.swift
@@ -54,7 +54,7 @@ public class SwiftFlutterBarcodeScannerPlugin: NSObject, FlutterPlugin, ScanBarc
     
     public static func onBarcodeScanReceiver( barcode:String){
         if let stream = barcodeStream {
-            barcodeStream!(barcode)
+            stream(barcode)
         }
     }
     
@@ -467,7 +467,7 @@ class BarcodeScannerViewController: UIViewController {
     
     
     /// Cancel button click event listener
-    @IBAction func cancelButtonClicked() {
+    @IBAction private func cancelButtonClicked() {
         if SwiftFlutterBarcodeScannerPlugin.isContinuousScan{
             self.dismiss(animated: true, completion: {
                 SwiftFlutterBarcodeScannerPlugin.onBarcodeScanReceiver(barcode: "-1")

--- a/lib/flutter_barcode_scanner.dart
+++ b/lib/flutter_barcode_scanner.dart
@@ -18,6 +18,10 @@ class FlutterBarcodeScanner {
 
   static Stream? _onBarcodeReceiver;
 
+  static dismiss() {
+    _channel.invokeMethod('dismiss', {'dismissScanner': '1'});
+  }
+
   /// Scan with the camera until a barcode is identified, then return.
   ///
   /// Shows a scan line with [lineColor] over a scan window. A flash icon is


### PR DESCRIPTION
Scanning can be closed programmatically with `FlutterBarcodeScanner.dismiss();`
Solves: 
- https://github.com/AmolGangadhare/flutter_barcode_scanner/issues/115
- https://github.com/AmolGangadhare/flutter_barcode_scanner/issues/30